### PR TITLE
refactor: update audit workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ">=1.19.0"
 
       - name: Verify dependencies
         run: go mod verify
@@ -50,4 +50,4 @@ jobs:
           fi
 
       - name: Test
-        run: go test -race -vet=off ./...
+        run: make test

--- a/makefile
+++ b/makefile
@@ -6,17 +6,16 @@ help:
 
 ## audit: format, vet, and test code
 .PHONY: audit 
-audit:
+audit: test
 	@echo "Formatting code."
 	gofumpt -w .
 	@echo "Vetting code."
 	go vet ./...
 	staticcheck ./...
-	@echo "Running tests."
-	go test -race -vet=off ./...
 
-ver = $(shell git describe --always --dirty --tags --long)
-linker_flags = "-s -X 'tshaka.co/bat/internal/cli.ver=${ver}'"
+tag = $(shell git describe --always --dirty --tags --long)
+linker_flags = "-s -X 'tshaka.co/bat/internal/cli.tag=${tag}'"
+
 ## build: build the cmd/bat application
 .PHONY: build
 build:
@@ -28,3 +27,9 @@ build:
 release: build
 	@echo "Packaging bat."
 	zip bat.zip ./bat
+
+## test: runs tests
+.PHONY: test 
+test: 
+	@echo "Running tests."
+	go test -v -race -vet=off -ldflags=${linker_flags} ./...


### PR DESCRIPTION
Bump the Go version and switch testing command to the one defined in the Makefile with linker flags.