### PR TITLE
refactor: revert to manual option parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OPTIONS
     -h, --help      
         Print this help document.
 
-    --version
+    -v, --version
         Display version information and exit.
 
 COMMANDS


### PR DESCRIPTION
The flag is not flexible enough especially with regards to output redirection and having shorthand options.