### PR TITLE
docs: update documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Tshaka Eric Lekholoane
+Copyright (c) 2021 Tshaka Eric Lekholoane
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SYNOPSIS
 
 OPTIONS
     -d, --debug
-       Display debug information.
+        Display debug information.
 
     -h, --help
         Print this help document.

--- a/help.fmt
+++ b/help.fmt
@@ -9,7 +9,7 @@ SYNOPSIS
 
 OPTIONS
     -d, --debug
-       Display debug information. Please use this when filing an issue.
+        Display debug information. Please use this when filing an issue.
 
     -h, --help
         Display this help document and exit.

--- a/main_linux.go
+++ b/main_linux.go
@@ -146,7 +146,7 @@ func main() {
 	}
 
 	if opts.version {
-		fmt.Printf(version, tag, time.Now().Year())
+		fmt.Printf(version, tag)
 		return
 	}
 

--- a/version.fmt
+++ b/version.fmt
@@ -1,3 +1,3 @@
 bat %s
-Copyright (c) %d Tshaka Lekholoane.
+Copyright (c) 2021 Tshaka Lekholoane.
 MIT Licence.


### PR DESCRIPTION
- Use original copyright year.
- Add whitespace before debug flag description.