### PR TITLE
Add a mention to the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ You can also rename the binary to something else if another program with the sam
 **AUR** : Note that if you download [the AUR package](https://aur.archlinux.org/packages/bat-asus-battery-bin), the command is 
 
 ```shell
-bat-asus-battery <command>
+bat-asus-battery command
 ```
-For more informatiion, see the [wiki](https://wiki.archlinux.org/title/Laptop/ASUS#Battery_charge_threshold).
+For more information, see the [wiki](https://wiki.archlinux.org/title/Laptop/ASUS#Battery_charge_threshold).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ ln -s $HOME/Downloads/bat /usr/local/bin/bat
 
 You can also rename the binary to something else if another program with the same name already exists i.e. [bat](https://github.com/sharkdp/bat).
 
+**AUR** : Note that if you download [the AUR package](https://aur.archlinux.org/packages/bat-asus-battery-bin), the command is 
+
+```shell
+bat-asus-battery <command>
+```
+For more informatiion, see the [wiki](https://wiki.archlinux.org/title/Laptop/ASUS#Battery_charge_threshold).
+
 ## Examples
 
 ```shell


### PR DESCRIPTION
Hi ! After installing from the AUR (as I do for most of my packages) I saw that the command wasn't bat by default but "bat-asus-battery". I modified a bit the readme to include a mention to it and a link to the part of the arch wiki that mentions this package